### PR TITLE
(#1) Make isRemote() more robust

### DIFF
--- a/lib/DirectAdmin_Domain.php
+++ b/lib/DirectAdmin_Domain.php
@@ -44,7 +44,7 @@ class DirectAdmin_Domain {
 	 */
 	public function isRemote(){
 		$api = new DirectAdmin_API();
-		$records = $api->getDomainsMxRecords($this->domain);
+		$records = $api->getDomainsMxRecords($this->domain, $this->username);
 		return isset($records[0]['isRemote']) && $records[0]['isRemote'];
 	}
 	


### PR DESCRIPTION
Instead of depending on a MX record to decide if mail is handled remotely or not it makes more sense to ask DirectAdmin what we should do. The decision is now based on CMD_API_DNS_MX which returns either yes or no.