### PR TITLE
(#1) Add back the original check as a precaution

### DIFF
--- a/lib/DirectAdmin_API.php
+++ b/lib/DirectAdmin_API.php
@@ -84,6 +84,14 @@ class DirectAdmin_API {
 			parse_str(substr($line, strlen($recordType)+1), $details);
 			foreach ($details as $record => $v){
 				$fixedRecord = str_replace('_', '.', $record);
+
+				// If the checkbox at CMD_API_DNS_MX isn't checked make sure we run an additional test
+				if ($isRemote == FALSE) {
+					if (substr($fixedRecord, -1) == '.' && strpos($fixedRecord, $domain) === false) {
+						$isRemote = TRUE;
+					}
+				}
+
 				$records[] = array(
 					'original'	=> $fixedRecord,
 					'full'		=> substr($fixedRecord, -1) == '.' ? substr($fixedRecord, 0, -1) : $fixedRecord . '.' . $domain,


### PR DESCRIPTION
There are still cases where users forget to change the local mail server setting in DirectAdmin. The original check will catch those mistakes which is why it makes sense to add it back in. If a user has only changed the A record of an existing MX record and did not change the local mail server setting it will not find it.