### PR TITLE
MMA-5061 fix Evolution skip Update inception issue

### DIFF
--- a/admin/update.html
+++ b/admin/update.html
@@ -18,5 +18,5 @@ $mainconf = new Configuration('plugin.conf');
     <br/>
     <br/>
     <br/>
-    <a href="/CMD_PLUGIN_MANAGER" class="btn btn-primary">Click to update</a>
+    <a href="/CMD_PLUGIN_MANAGER" target="_parent" class="btn btn-primary">Click to update</a>
 </div>


### PR DESCRIPTION
This PR fixes an issue from Evolution skin upgrade, where the Update button from the Professional Spam Filter doesn't 
redirect to plugins manger page(/CMD_PLUGIN_MANAGER), but instead opens a site inception. See the image below 
<img width="1291" alt="Screenshot 2021-09-08 at 11 16 38" src="https://user-images.githubusercontent.com/52916601/132472654-0f18fd13-4578-4b45-a1d9-d10420640564.png">
@